### PR TITLE
Ignore groups without attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ Auth.prototype.authenticate = function (user, password, callback) {
           ldapUser.memberOf = [ldapUser.memberOf];
         }
         for (var i = 0; i < ldapUser.memberOf.length; i++) {
-          groups.push(parseDN(ldapUser.memberOf[i]).rdns[0].attrs[self._config.groupNameAttribute].value);
+          if (Object.keys(parseDN(ldapUser.memberOf[i]).rdns[0].attrs).indexOf(self._config.groupNameAttribute) > -1) {
+            groups.push(parseDN(ldapUser.memberOf[i]).rdns[0].attrs[self._config.groupNameAttribute].value);
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "verdaccio-ldap",
+  "name": "verdaccio-ldap-fork",
   "version": "1.2.0",
   "description": "LDAP auth plugin for verdaccio",
   "author": "Alexandre L.",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Alexandre-io/verdaccio-ldap.git"
+    "url": "git@github.com:larrabee/verdaccio-ldap.git"
   },
   "dependencies": {
     "ldapauth-fork": "~4.0.0",


### PR DESCRIPTION
Hello. This fix following error:
```
TypeError: Cannot read property 'value' of undefined
 at /opt/sinopia/node_modules/verdaccio-ldap/index.js:61:99
at /opt/sinopia/node_modules/ldapauth-fork/lib/ldapauth.js:378:20
at /opt/sinopia/node_modules/bcryptjs/dist/bcrypt.js:1353:21
at Immediate.next [as _onImmediate] (/opt/sinopia/node_modules/bcryptjs/dist/bcrypt.js:1233:21)
at runCallback (timers.js:781:20)
at tryOnImmediate (timers.js:743:5)
at processImmediate [as _immediateCallback] (timers.js:714:5)
```
It caused because groupNameAttribute: 'cn', but user can have group like this 'ipaUniqueID=9f2794ea-024c-11e7-80e5-525400sssss,cn=hbac,dc=test,dc=com'.
With fix this groups will be ignored.