### PR TITLE
Guard for memberOf that do not begin with <groupNameAttribute>=

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ Auth.prototype.authenticate = function (user, password, callback) {
           ldapUser.memberOf = [ldapUser.memberOf];
         }
         for (var i = 0; i < ldapUser.memberOf.length; i++) {
-          groups.push(parseDN(ldapUser.memberOf[i]).rdns[0].attrs[self._config.groupNameAttribute].value);
+          var attrs = parseDN(ldapUser.memberOf[i]).rdns[0].attrs;
+          if (attrs[self._config.groupNameAttribute] && attrs[self._config.groupNameAttribute].value !== undefined) {
+            groups.push(attrs[self._config.groupNameAttribute].value);
+          }
         }
       }
     }


### PR DESCRIPTION
Thanks for creating this plugin, it's been working great for us, but we did notice a small issue.

Some ldap users have a memberOf array that looks like the following:

```
[
  "cn=admins,cn=groups,cn=accounts,dc=domain,dc=com",
  "ipaUniqueID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,cn=sudorules,cn=sudo,dc=domain,dc=com",
  "cn=ipausers,cn=groups,cn=accounts,dc=domain,dc=com"
]
```

So the `groupNameAttribute` is `cn` but some of the rules do not start with `cn=`.

The above example currently causes this plugin to crash `verdaccio` so I've added a guard in the code which just skips groups that do not start with the `groupNameAttribute`.