### PR TITLE
make finally() in authentication sequence return the LDAP user

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ Auth.prototype.authenticate = function (user, password, callback) {
 
       return false; // indicates failure
     })
-    .finally(() => {
+    .finally((ldapUser) => {
       /*
        * LdapClient.closeAsync doesn't work with node 10.x
        * 
@@ -61,7 +61,8 @@ Auth.prototype.authenticate = function (user, password, callback) {
        *      }, 'LDAP error on close @{err}');
        *  });
        */
-      return LdapClient.close(callback);        
+      LdapClient.close();
+      return ldapUser;
     })
     .asCallback(callback);
 };


### PR DESCRIPTION
Make finally() in authentication sequence return the LDAP user and ignore LdapClient.close(), otherwise the callback is called with the UnbindResponse from LdapClient.close().