### PR TITLE
fix(memberOf): handle non-array memberOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@ Auth.prototype.authenticate = function (user, password, callback) {
       
       return [
         ldapUser.cn,
-        ...ldapUser._groups ? ldapUser._groups.map((group) => group.cn) : [],
-        ...ldapUser.memberOf ? ldapUser.memberOf.map((groupDn) => rfc2253.parse(groupDn).get('CN')) : [],
+        // _groups or memberOf could be single els or arrays.
+        ...ldapUser._groups ? [].concat(ldapUser._groups).map((group) => group.cn) : [],
+        ...ldapUser.memberOf ? [].concat(ldapUser.memberOf).map((groupDn) => rfc2253.parse(groupDn).get('CN')) : [],
       ];
     })
     .catch((err) => {


### PR DESCRIPTION
Fixes this issue, which seems to occur when a user is a member of only a single group:

> warn --- LDAP error { message: 'ldapUser.memberOf.map is not a function',
 name: 'TypeError',
 stack: 'TypeError: ldapUser.memberOf.map is not a function\n    at LdapClient.authenticateAsync.then (/app/node_modules/verdaccio-ldap/index.js:41:48)\n    at tryCatcher (/app/node_modules/bluebird/js/release/util.js:16:23)\n    at Promise._settlePromiseFromHandler (/app/node_modules/bluebird/js/release/promise.js:512:31)\n    at Promise._settlePromise (/app/node_modules/bluebird/js/release/promise.js:569:18)\n    at Promise._settlePromise0 (/app/node_modules/bluebird/js/release/promise.js:614:10)\n    at Promise._settlePromises (/app/node_modules/bluebird/js/release/promise.js:693:18)\n    at Promise._fulfill (/app/node_modules/bluebird/js/release/promise.js:638:18)\n    at /app/node_modules/bluebird/js/release/nodeback.js:42:21\n    at /app/node_modules/ldapauth-fork/lib/ldapauth.js:381:18\n    at LdapAuth._getGroups (/app/node_modules/ldapauth-fork/lib/ldapauth.js:125:14)\n    at /app/node_modules/ldapauth-fork/lib/ldapauth.js:366:12\n    at sendResult (/app/node_modules/ldapjs/lib/client/client.js:1395:12)\n    at messageCallback (/app/node_modules/ldapjs/lib/client/client.js:1421:16)\n    at Parser.onMessage (/app/node_modules/ldapjs/lib/client/client.js:1089:14)\n    at emitOne (events.js:116:13)\n    at Parser.emit (events.js:211:7)'