### PR TITLE
fix(auth): fix ldap auth cache by creating authClient on construct in…

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Auth(config, stuff) {
   // TODO: Set more defaults
   self._config.groupNameAttribute = self._config.groupNameAttribute || 'cn';
 
+  self._ldapClient = new LdapAuth(self._config.client_options);
   return self;
 }
 
@@ -29,12 +30,11 @@ module.exports = Auth;
 // Attempt to authenticate user against LDAP backend
 //
 Auth.prototype.authenticate = function (user, password, callback) {
-  const LdapClient = new LdapAuth(this._config.client_options);
-
+  const self = this;
   // https://github.com/vesse/node-ldapauth-fork/issues/61
-  LdapClient.on('error', (err) => {});
+  self._ldapClient.on('error', (err) => {});
 
-  LdapClient.authenticateAsync(user, password)
+  self._ldapClient.authenticateAsync(user, password)
     .then((ldapUser) => {
       if (!ldapUser) return [];
 
@@ -55,7 +55,7 @@ Auth.prototype.authenticate = function (user, password, callback) {
       return false; // indicates failure
     })
     .finally((ldapUser) => {
-      LdapClient.closeAsync()
+      self._ldapClient.closeAsync()
         .catch((err) => {
           this._logger.warn({
             err: err

--- a/tests/integration/test.spec.js
+++ b/tests/integration/test.spec.js
@@ -3,23 +3,21 @@ const should = require('chai').should();
 const bunyan = require('bunyan');
 const log = bunyan.createLogger({ name: 'myapp' });
 
-
-const auth = new Auth({
-  client_options: {
-    url: "ldap://localhost:4389",
-    searchBase: 'ou=users,dc=myorg,dc=com',
-    searchFilter: '(&(objectClass=posixAccount)(!(shadowExpire=0))(uid={{username}}))',
-    groupDnProperty: 'cn',
-    groupSearchBase: 'ou=groups,dc=myorg,dc=com',
-    // If you have memberOf:
-    searchAttributes: ['*', 'memberOf'],
-    // Else, if you don't:
-    // groupSearchFilter: '(memberUid={{dn}})',
-  }
-}, { logger: log });
-
 describe('ldap auth', function () {
   it('should match user', function (done) {
+    const auth = new Auth({
+      client_options: {
+        url: "ldap://localhost:4389",
+        searchBase: 'ou=users,dc=myorg,dc=com',
+        searchFilter: '(&(objectClass=posixAccount)(!(shadowExpire=0))(uid={{username}}))',
+        groupDnProperty: 'cn',
+        groupSearchBase: 'ou=groups,dc=myorg,dc=com',
+        // If you have memberOf:
+        searchAttributes: ['*', 'memberOf'],
+        // Else, if you don't:
+        // groupSearchFilter: '(memberUid={{dn}})',
+      }
+    }, { logger: log });
     auth.authenticate('user', 'password', function (err, results) {
       (err === null).should.be.true;
       results[0].should.equal('user');


### PR DESCRIPTION
Inspired from: 

- https://github.com/Alexandre-io/verdaccio-ldap/pull/40#issuecomment-407606869
- https://github.com/Alexandre-io/verdaccio-ldap/issues/39#issuecomment-407420495

Test: OK

## How to test

Use the test release version on `npm`:

```sh
$ npm install -g verdaccio-ldap-fixed-cache@2.3.0
```

You will need at least to rename your `ldap` config in your `config.yaml`:

```yaml
auth:
  # Note: to people who want to test it
  # this MUST be the suffix of the module so here it is ldap-node-cache instead of ldap 
 verdaccio-ldap-fixed-cache:
    type: ldap
    client_options:
      cache: true
```

It is also possible to test with Docker:

```Dockerfile
FROM verdaccio/verdaccio:3
RUN yarn add verdaccio-ldap-fixed-cache@2.3.0
```

### Related resources

- #37 