### PR TITLE
Add cache capacity to this plugin itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Add to your `config.yaml`:
 auth:
   ldap:
     type: ldap
+    # Optional, default false.
+    # If true, then up to 100 credentials at a time will be cached for 5 minutes.
+    cache: false
     client_options:
       url: "ldaps://ldap.example.com"
       # Only required if you need auth to bind
@@ -32,10 +35,7 @@ auth:
       searchAttributes: ['*', 'memberOf']
       # Else, if you don't (use one or the other):
       # groupSearchFilter: '(memberUid={{dn}})'
-      # 
-      # Optional, default false.
-      # If true, then up to 100 credentials at a time will be cached for 5 minutes.
-      cache: false
+      #
       # Optional
       reconnect: true
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/Alexandre-io/verdaccio-ldap.git"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "bluebird": "~3.5.1",
     "ldapauth-fork": "~4.0.2",
     "rfc2253": "~0.1.1"

--- a/tests/integration/test.spec.js
+++ b/tests/integration/test.spec.js
@@ -3,7 +3,6 @@ const should = require('chai').should();
 const bunyan = require('bunyan');
 const log = bunyan.createLogger({ name: 'verdaccio-ldap' });
 
-
 describe('ldap auth', function () {
   it('should match user', function (done) {
 
@@ -27,5 +26,35 @@ describe('ldap auth', function () {
       done();
     });
 
+  });
+
+  it('should use cache', function (done) {
+    const auth = new Auth({
+      cache: true,
+      client_options: {
+        url: "ldap://localhost:4389",
+        searchBase: 'ou=users,dc=myorg,dc=com',
+        searchFilter: '(&(objectClass=posixAccount)(!(shadowExpire=0))(uid={{username}}))',
+        groupDnProperty: 'cn',
+        groupSearchBase: 'ou=groups,dc=myorg,dc=com',
+        // If you have memberOf:
+        searchAttributes: ['*', 'memberOf'],
+        // Else, if you don't:
+        // groupSearchFilter: '(memberUid={{dn}})',
+      }
+    }, { logger: log });
+
+    auth.authenticate('user', 'password', function (err, results) {
+      (err === null).should.be.true;
+      (results.cacheHit === undefined).should.be.true;
+      results[0].should.equal('user');
+
+      auth.authenticate('user', 'password', function (err, results) {
+        (err === null).should.be.true;
+        results.cacheHit.should.be.true;
+        results[0].should.equal('user');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
verdaccio-ldap fix ldap cache by using a single instance of ldapauth in https://github.com/Alexandre-io/verdaccio-ldap/pull/42, but it cause another problem, see https://github.com/vesse/node-ldapauth-fork/issues/23, it's related to https://github.com/joyent/node-ldapjs/issues/318. as this https://github.com/vesse/node-ldapauth-fork/issues/23#issuecomment-154487871 point up, use new client for each auth would avoid this. 

this pr move cache capacity from [ldapauth](https://github.com/vesse/node-ldapauth-fork) to this plugin itself.