### PR TITLE
Make groupNameAttribute option take effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Add to your `config.yaml`:
 auth:
   ldap:
     type: ldap
+    # Only required if you are fetching groups that do not have a "cn" property. defaults to "cn"
+    groupNameAttribute: "ou"
     client_options:
       url: "ldaps://ldap.example.com"
       # Only required if you need auth to bind
@@ -34,7 +36,7 @@ auth:
       searchAttributes: ['*', 'memberOf']
       # Else, if you don't (use one or the other):
       # groupSearchFilter: '(memberUid={{dn}})'
-      # 
+      #
       # Optional, default false.
       # If true, then up to 100 credentials at a time will be cached for 5 minutes.
       cache: false
@@ -76,4 +78,4 @@ This should export two functions:
     - `cb(null, [groups])` in case user is authenticated
 
    Groups is an array of all users/usergroups this user has access to. You should probably include username itself here.
-   
+

--- a/index.js
+++ b/index.js
@@ -35,20 +35,6 @@ function Auth(config, stuff) {
 module.exports = Auth;
 
 //
-// Convert each of the user group search results into a group name string
-//
-Auth.prototype.getGroupForGroup = function (group) {
-  return group[this._config.groupNameAttribute];
-};
-
-//
-// Convert each user.memberOf into a group name string
-//
-Auth.prototype.getGroupForMemberOf = function (groupDn) {
-  return rfc2253.parse(groupDn).get('CN');
-};
-
-//
 // Attempt to authenticate user against LDAP backend
 //
 Auth.prototype.authenticate = function (user, password, callback) {
@@ -60,8 +46,8 @@ Auth.prototype.authenticate = function (user, password, callback) {
       return [
         ldapUser.cn,
         // _groups or memberOf could be single els or arrays.
-        ...ldapUser._groups ? [].concat(ldapUser._groups).map(this.getGroupForGroup) : [],
-        ...ldapUser.memberOf ? [].concat(ldapUser.memberOf).map(this.getGroupForMemberOf) : [],
+        ...ldapUser._groups ? [].concat(ldapUser._groups).map((group) => group[this._config.groupNameAttribute]) : [],
+        ...ldapUser.memberOf ? [].concat(ldapUser.memberOf).map((groupDn) => rfc2253.parse(groupDn).get('CN')) : [],
       ];
     })
     .catch((err) => {


### PR DESCRIPTION
Hi there, thanks for building such a great verdaccio plugin.

I noticed that the `groupNameAttribute` config option is present, but not currently doing anything.

I have a use case for needing that config option to be connected.

I want it to control what attribute of the group search result objects are going to be used for the group name.

Here's a real verdaccio `config.yaml` (public ldap server) showing my use case:


```yaml
auth:
  ldap:
    type: ldap
    groupNameAttribute: 'ou'
    client_options:
      url: "ldap://ldap.forumsys.com:389"
      bindDn: "cn=read-only-admin,dc=example,dc=com"
      bindCredentials: "password"
      adminDn: "cn=read-only-admin,dc=example,dc=com"
      adminPassword: "password"
      searchBase: "dc=example,dc=com"
      searchFilter: "(uid={{username}})"
      searchAttributes:
        - "*"
      groupSearchBase: "dc=example,dc=com"
      groupSearchFilter: "(uniqueMember=uid={{username}},dc=example,dc=com)"
      groupSearchAttributes:
        - dn
        - ou
      cache: False
      tlsOptions:
        rejectUnauthorized: False

# Only users who are members of the verdaccio ldap group will be able to access or publish packages:

packages:
  '@porterjs/*':
    # your scoped packages - don't proxy requests since these packages only exist on our server
    access: scientists
    publish: scientists
    proxy: npmjs

  '**':
    # for all non scoped packages - proxy requests to 'npmjs' registry
    access: scientists
    publish: scientists
    proxy: npmjs
```

The result of running the group search is the same as this command:

`ldapsearch -x -w password -h ldap.forumsys.com -D cn=read-only-admin,dc=example,dc=com -b dc=example,dc=com "(uniqueMember=uid=tesla,dc=example,dc=com)"`

Which results in:

```
# scientists, example.com
dn: ou=scientists,dc=example,dc=com
uniqueMember: uid=einstein,dc=example,dc=com
uniqueMember: uid=galieleo,dc=example,dc=com
uniqueMember: uid=tesla,dc=example,dc=com
uniqueMember: uid=newton,dc=example,dc=com
uniqueMember: uid=training,dc=example,dc=com
uniqueMember: uid=jmacy,dc=example,dc=com
ou: scientists
cn: Scientists
objectClass: groupOfUniqueNames
objectClass: top

# italians, scientists, example.com
dn: ou=italians,ou=scientists,dc=example,dc=com
uniqueMember: uid=tesla,dc=example,dc=com
ou: italians
cn: Italians
objectClass: groupOfUniqueNames
objectClass: top

# search result
search: 2
result: 0 Success

# numResponses: 3
# numEntries: 2
```

I need to be able to use the `ou` field of the group result records to get `scientists` and **not** `Scientists`.

The `groupNameAttribute` option fills this need perfectly. :-)

