### PR TITLE
Fix authentication issues (fix #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ auth:
     type: ldap
     # Only required if you are fetching groups that do not have a "cn" property. defaults to "cn"
     groupNameAttribute: "ou"
+    # Optional, default false.
+    cache:
+      # max credentials to cache (default to 100 if cache is enabled)
+      size: 100
+      # cache expiration in seconds (default to 300 if cache is enabled)
+      expire: 300
     client_options:
       url: "ldaps://ldap.example.com"
       # Only required if you need auth to bind
@@ -36,10 +42,6 @@ auth:
       searchAttributes: ['*', 'memberOf']
       # Else, if you don't (use one or the other):
       # groupSearchFilter: '(memberUid={{dn}})'
-      #
-      # Optional, default false.
-      # If true, then up to 100 credentials at a time will be cached for 5 minutes.
-      cache: false
       # Optional
       reconnect: true
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/Alexandre-io/verdaccio-ldap.git"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "bluebird": "~3.5.2",
     "ldapauth-fork": "~4.2.0",
     "rfc2253": "~0.1.1"
@@ -20,7 +21,7 @@
     "mocha": "~6.1.0"
   },
   "scripts": {
-    "pretest": "./node_modules/jshint/bin/jshint .",
+    "pretest": "jshint .",
     "test": "mocha --exit tests/bootstrap.spec.js tests/**/*.spec.js"
   },
   "keywords": [

--- a/tests/integration/test.spec.js
+++ b/tests/integration/test.spec.js
@@ -28,4 +28,34 @@ describe('ldap auth', function () {
     });
 
   });
+
+  it('should use cache', function (done) {
+    const auth = new Auth({
+      cache: true,
+      client_options: {
+        url: "ldap://localhost:4389",
+        searchBase: 'ou=users,dc=myorg,dc=com',
+        searchFilter: '(&(objectClass=posixAccount)(!(shadowExpire=0))(uid={{username}}))',
+        groupDnProperty: 'cn',
+        groupSearchBase: 'ou=groups,dc=myorg,dc=com',
+        // If you have memberOf:
+        searchAttributes: ['*', 'memberOf'],
+        // Else, if you don't:
+        // groupSearchFilter: '(memberUid={{dn}})',
+      }
+    }, { logger: log });
+
+    auth.authenticate('user', 'password', function (err, results) {
+      (err === null).should.be.true;
+      should.not.exist(results.cacheHit);
+      results[0].should.equal('user');
+
+      auth.authenticate('user', 'password', function (err, results) {
+        (err === null).should.be.true;
+        results.cacheHit.should.be.true;
+        results[0].should.equal('user');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
This pull request fixes authentication issues reported in #47.
As I explained in the comments:

> It seems to be related with LDAP bind requests and concurrency. I can reproduce the bug when multiple authentications are made "simultaneously" (try to disable cache to reproduce the issue more easily).

Using only one instance of LdapAuth causes this. A new instance need to be created for each new authentication like it was before this pull request: #42 . See vesse/node-ldapauth-fork#23 and joyent/node-ldapjs#318 for more informations. The cache is now manage by the plugin itself.


Changes made here are heavly inspirated by this PR: #46  (but seems to be abandoned).

Since I use my fork (for more than 6 months now) everything works fine and I don't have any authentication issues anymore.

Note that unbinding connections (`ldapClient.closeAsync`) do nothing on Node 10 (see joyent/node-ldapjs#483), but a fix have been proposed (joyent/node-ldapjs#497)