### PR TITLE
Reduce test delay

### DIFF
--- a/tests/bootstrap.spec.js
+++ b/tests/bootstrap.spec.js
@@ -2,8 +2,14 @@ const { spawn } = require('child_process');
 let server;
 
 before(function (done) {
-    server = spawn('node', ['node_modules/ldap-server-mock/server.js', '--conf=../../tests/ldap-server-mock-conf.json', '--database=../../tests/users.json']);
-    setTimeout(done, 1000);
+    server = spawn('node', ['node_modules/ldap-server-mock/server.js', '--conf=../../tests/ldap-server-mock-conf.json', '--database=../../tests/users.json'], {
+      stdio: ['ipc']
+    });
+    server.on('message', (message) => {
+      if (message.status === 'started') {
+        done();
+      }
+    })
 });
 
 after(function (done) {


### PR DESCRIPTION
Instead of waiting an entire second before starting tests, this waits only the minimal amount of time necessary.