### PR TITLE
Support using env to set adminPassword

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ auth:
       reconnect: true
 ```
 
+### LDAP Admin Password
+If you run this plugin in k8s, you may want to set password by env with secretRef.
+You can use `LDAP_ADMIN_PASS` to set ldap admin password, it will override the one in `config.yaml`.
+
 ## For plugin writers
 
 It's called as:

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ const LdapAuth = require('ldapauth-fork');
 const Cache = require('ldapauth-fork/lib/cache');
 const bcrypt = require('bcryptjs');
 
+// environment variable name to set ldap admin password
+// Note: it will override the one in config file.
+const LDAP_ADMIN_PASS_ENV = 'LDAP_ADMIN_PASS';
+
 Promise.promisifyAll(LdapAuth.prototype);
 
 function authenticatedUserGroups(user, groupNameAttribute) {
@@ -39,6 +43,10 @@ function Auth(config, stuff) {
     const expire = typeof config.cache.expire === 'number' ? config.cache.expire : 300;
     self._userCache = new Cache(size, expire, stuff.logger, 'user');
     self._salt = bcrypt.genSaltSync();
+  }
+
+  if (LDAP_ADMIN_PASS_ENV in process.env) {
+    self._config.client_options.adminPassword = process.env[LDAP_ADMIN_PASS_ENV];
   }
 
   return self;

--- a/package-lock.json
+++ b/package-lock.json
@@ -683,12 +683,12 @@
       "dev": true
     },
     "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
       "requires": {
         "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
+        "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
       }
@@ -2288,9 +2288,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
       "optional": true
     },
     "ms": {

--- a/tests/integration/test.spec.js
+++ b/tests/integration/test.spec.js
@@ -79,4 +79,47 @@ describe('ldap auth', function () {
       });
     });
   });
+
+  describe('test admin password', () => {
+    let config;
+    const password = '1234';
+    before(() => {
+      config = {
+        cache: true,
+        client_options: {
+          url: "ldap://localhost:4389",
+          searchBase: 'ou=users,dc=myorg,dc=com',
+          searchFilter: '(&(objectClass=posixAccount)(!(shadowExpire=0))(uid={{username}}))',
+          groupDnProperty: 'cn',
+          groupSearchBase: 'ou=groups,dc=myorg,dc=com',
+          // If you have memberOf:
+          searchAttributes: ['*', 'memberOf'],
+          // Else, if you don't:
+          // groupSearchFilter: '(memberUid={{dn}})',
+        }
+      };
+    });
+
+    it('should read password from config', function (done) {
+      config.client_options.adminPassword = password;
+      auth = new Auth(config, { logger: log });
+      auth._config.client_options.adminPassword.should.equal(password);
+      done()
+    })
+
+    it('should read password from env if exist', function(done) {
+      process.env.LDAP_ADMIN_PASS = password;
+      auth = new Auth(config, { logger: log });
+      auth._config.client_options.adminPassword.should.equal(password);
+      done()
+    })
+
+    it('should override password from env if exist', function(done) {
+      config.client_options.adminPassword = 'asdf';
+      process.env.LDAP_ADMIN_PASS = password;
+      auth = new Auth(config, { logger: log });
+      auth._config.client_options.adminPassword.should.equal(password);
+      done()
+    })
+  })
 });


### PR DESCRIPTION
If you run this plugin in kubernetes, you may want to set password by env with `secretRef` so that the password can be securely store in kubernetes `Secret`.

This PR add an env `LDAP_ADMIN_PASS` to allow use override the password.