### PR TITLE
fix: add logger adapter for Verdaccio 6.2.1+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.0.1 / 2025-11-27
+- Fix compatibility with Verdaccio 6.2.1+ by creating logger adapter for ldapjs
+- Resolves "TypeError: options.log must be an object" error
+
 # 6.0.0 / 2022-10-02
 - Update npm dependencies
 - Cache: use md5 instead of bcryptjs

--- a/index.js
+++ b/index.js
@@ -30,7 +30,19 @@ function Auth(config, stuff) {
   self._logger = stuff.logger;
 
   // pass verdaccio logger to ldapauth
-  self._config.client_options.log = stuff.logger;
+  // Create a logger adapter compatible with ldapjs/bunyan
+  // Verdaccio 6.2.1+ changed the logger structure, so we need to adapt it
+  const loggerAdapter = {
+    trace: (...args) => self._logger.trace && self._logger.trace(...args),
+    debug: (...args) => self._logger.debug && self._logger.debug(...args),
+    info: (...args) => self._logger.info && self._logger.info(...args),
+    warn: (...args) => self._logger.warn && self._logger.warn(...args),
+    error: (...args) => self._logger.error && self._logger.error(...args),
+    fatal: (...args) => self._logger.fatal && self._logger.fatal(...args),
+    // ldapjs expects a child() method for creating child loggers
+    child: () => loggerAdapter,
+  };
+  self._config.client_options.log = loggerAdapter;
 
   // always set ldapauth cache false
   self._config.client_options.cache = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verdaccio-ldap",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "LDAP auth plugin for verdaccio",
   "author": "Alexandre L.",
   "repository": {


### PR DESCRIPTION
- Create logger adapter compatible with ldapjs/bunyan requirements
- Verdaccio 6.2.1+ changed logger structure breaking ldapjs integration
- Add child() method required by ldapjs for creating child loggers
- Resolves "TypeError: options.log must be an object" error

BREAKING CHANGE: none
Fixes: compatibility with Verdaccio 6.2.1 and 6.2.2
Tested: all 6 unit tests passing